### PR TITLE
Add CNAME to build output

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+umlcloudcomputing.org

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "import": "node stream.js && rm -rf temp",
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
-    "build": "docusaurus build",
+    "build": "docusaurus build && cp CNAME build/",
     "swizzle": "docusaurus swizzle",
     "deploy": "gh-pages -d build",
     "clear": "docusaurus clear",


### PR DESCRIPTION
Adds the CNAME file to the /build folder output by modifying the `npm run build` command in package.json. This should fix the issue of overwriting the CNAME file on every new PR. 